### PR TITLE
Streamline bookinfo example

### DIFF
--- a/examples/bookinfo/bookinfo-translator.js
+++ b/examples/bookinfo/bookinfo-translator.js
@@ -23,13 +23,13 @@
 let solsa = require('solsa')
 let bookinfo = require('./bookinfo.js')
 
-module.exports = function translatingBookinfo ({ name, language }) {
-  // Create an instance of the vanilla Bookinfo application pattern
-  let bundle = bookinfo({ name: name })
+module.exports = function translatingBookinfo ({ language }) {
+  // Create an instance of the basic Bookinfo application pattern
+  let bundle = bookinfo()
 
   // Configure a translating review service
-  bundle.translator = new solsa.LanguageTranslator({ name: `${name}-watson-translator` })
-  bundle.translatedReviews = new solsa.ContainerizedService({ name: `${name}-reviews-translator`, image: 'solsa-reviews-translator', build: __dirname, main: 'reviews-translator.js', port: 9080 })
+  bundle.translator = new solsa.LanguageTranslator({ name: 'bookinfo-watson-translator' })
+  bundle.translatedReviews = new solsa.ContainerizedService({ name: 'reviews-translator', image: 'solsa-reviews-translator', build: __dirname, main: 'reviews-translator.js', port: 9080 })
   bundle.translatedReviews.env = {
     LANGUAGE: { value: language },
     WATSON_TRANSLATOR_URL: bundle.translator.getSecret('url'),
@@ -39,7 +39,7 @@ module.exports = function translatingBookinfo ({ name, language }) {
   }
   bundle.translatedReviews.readinessProbe = { httpGet: { path: '/solsa/readinessProbe', port: bundle.translatedReviews.port } }
 
-  // Modify existing Bookinfo productpage to use the translating review service
+  // Modify the Bookinfo productpage to use the translating review service
   bundle.productpage.env.REVIEWS_HOSTNAME = bundle.translatedReviews.name
 
   return bundle

--- a/examples/bookinfo/bookinfo.js
+++ b/examples/bookinfo/bookinfo.js
@@ -19,13 +19,13 @@
 
 let solsa = require('solsa')
 
-module.exports = function bookinfo ({ name }) {
+module.exports = function bookinfo () {
   let bundle = new solsa.Bundle()
 
-  bundle.details = new solsa.ContainerizedService({ name: `${name}-details`, image: 'istio/examples-bookinfo-details-v1:1.15.0', port: 9080 })
-  bundle.ratings = new solsa.ContainerizedService({ name: `${name}-ratings`, image: 'istio/examples-bookinfo-ratings-v1:1.15.0', port: 9080 })
-  bundle.reviews = new solsa.ContainerizedService({ name: `${name}-reviews`, image: 'istio/examples-bookinfo-reviews-v1:1.15.0', port: 9080 })
-  bundle.productpage = new solsa.ContainerizedService({ name: `${name}-productpage`, image: 'istio/examples-bookinfo-productpage-v1:1.15.0', port: 9080 })
+  bundle.details = new solsa.ContainerizedService({ name: 'details', image: 'istio/examples-bookinfo-details-v1:1.15.0', port: 9080 })
+  bundle.ratings = new solsa.ContainerizedService({ name: 'ratings', image: 'istio/examples-bookinfo-ratings-v1:1.15.0', port: 9080 })
+  bundle.reviews = new solsa.ContainerizedService({ name: 'reviews', image: 'istio/examples-bookinfo-reviews-v1:1.15.0', port: 9080 })
+  bundle.productpage = new solsa.ContainerizedService({ name: 'productpage', image: 'istio/examples-bookinfo-productpage-v1:1.15.0', port: 9080 })
   bundle.productpage.env = {
     DETAILS_HOSTNAME: bundle.details.name,
     RATINGS_HOSTNAME: bundle.ratings.name,

--- a/examples/bookinfo/instance-sp.js
+++ b/examples/bookinfo/instance-sp.js
@@ -16,4 +16,4 @@
 
 const bookinfo = require('./bookinfo-translator')
 
-module.exports = bookinfo({ name: 'my-library-es', language: 'spanish' })
+module.exports = bookinfo({ language: 'spanish' })

--- a/examples/bookinfo/instance.js
+++ b/examples/bookinfo/instance.js
@@ -15,5 +15,4 @@
  */
 
 const bookinfo = require('./bookinfo')
-
-module.exports = bookinfo({ name: 'my-library' })
+module.exports = bookinfo()


### PR DESCRIPTION
Streamline bookinfo example by removing the code to
add a unique prefix to the name of each ContainerizedService.